### PR TITLE
Fix multi-digit interface name highlighting regression

### DIFF
--- a/syntaxes/Junos.tmLanguage
+++ b/syntaxes/Junos.tmLanguage
@@ -177,7 +177,7 @@
 			<key>comment</key>
 			<string>Interface names</string>
 			<key>match</key>
-			<string>\b((((ge|et|so|fe|gr|xe|lt|vt|si|sp)(-(\d|\*)\/(\d|\*)\/(\d|\*)))|(st|lo|me|vme|ae)\d{1,3}|irb|vlan)(\.\d{1,5})?)(?![-_&lt;&gt;])</string>
+			<string>\b((((ge|et|so|fe|gr|xe|lt|vt|si|sp)(-(\d+|\*)\/(\d+|\*)\/(\d+|\*)))|(st|lo|me|vme|ae)\d{1,3}|irb|vlan)(\.\d{1,5})?)(?![-_&lt;&gt;])</string>
 			<key>name</key>
 			<string>support.class.junos</string>
 		</dict>


### PR DESCRIPTION
Fixes #6.

It looks like a regression was introduced with e49a83de7e90996c506c0484f59cd5d65b27515a where interface names with multiple digits were no longer highlighted properly.
